### PR TITLE
Fix bug discarding HTTP errors returned from API

### DIFF
--- a/client.go
+++ b/client.go
@@ -160,7 +160,7 @@ func (c *Client) do(ctx context.Context, method, path string, body io.Reader, qu
 		err = errors.Join(err, res.Body.Close())
 	}()
 
-	if res.StatusCode == http.StatusOK || res.StatusCode == http.StatusCreated || res.StatusCode != http.StatusNotFound {
+	if res.StatusCode == http.StatusOK || res.StatusCode == http.StatusCreated || res.StatusCode == http.StatusNotFound {
 		var root root
 
 		if err := json.NewDecoder(res.Body).Decode(&root); err != nil {


### PR DESCRIPTION
I tried creating a DNS record using this library, and because of an invalid input on my side the record could not be created. (The value I passed was not valid for the record type and the API returned an HTTP status code of 422 Unprocessable Entity.)

Instead of returning the error to my business logic though, the error was silently discarded in the library.

The faulty code appears to check for certain "successful" status codes, returning an error for all other status codes. In reality, however, the condition only fails if the status code is 404. This is because `!=` operator should probably be a `==` instead, similar to the other status codes.